### PR TITLE
bitboardで高速化

### DIFF
--- a/src/game/board.rs
+++ b/src/game/board.rs
@@ -1,90 +1,170 @@
 use super::piece::Piece;
+use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+// 勝利判定に使用するマスクを定数として定義
+const WINNING_MASKS: [u16; 10] = [
+    0x000F, 0x00F0, 0x0F00, 0xF000, // Rows
+    0x1111, 0x2222, 0x4444, 0x8888, // Columns
+    0x1248, 0x8421, // Diagonals
+];
+
+#[derive(Copy, Clone, Debug, PartialEq, Deserialize)]
 pub struct Board {
-    pub grid: [[Option<Piece>; 4]; 4],
+    color_board: u16,
+    shape_board: u16,
+    height_board: u16,
+    surface_board: u16,
+    empty_cells: u16, // 空のセルを管理するためのビットボード
 }
 
 impl Board {
     pub fn new() -> Self {
         Board {
-            grid: [[None; 4]; 4],
+            color_board: 0,
+            shape_board: 0,
+            height_board: 0,
+            surface_board: 0,
+            empty_cells: 0xFFFF, // 全てのマスが空であることを示す（16ビットすべてが1）
         }
     }
 
     pub fn place_piece(&mut self, row: usize, col: usize, piece: Piece) -> Result<(), String> {
-        if self.grid[row][col].is_some() {
-            Err("The cell is already occupied.".to_string())
-        } else {
-            self.grid[row][col] = Some(piece);
-            Ok(())
+        let position = 1 << (row * 4 + col); // 位置をビットシフトで表現
+
+        // すでにピースが置かれているセルには置けない
+        if self.empty_cells & position == 0 {
+            return Err("Cell is already occupied".to_string());
         }
+
+        // 空セルから除外
+        self.empty_cells &= !position;
+
+        // 各属性に対応するビットボードを更新
+        if piece.color() == 0 {
+            self.color_board |= position;
+        }
+        if piece.shape() == 0 {
+            self.shape_board |= position;
+        }
+        if piece.height() == 0 {
+            self.height_board |= position;
+        }
+        if piece.surface() == 0 {
+            self.surface_board |= position;
+        }
+
+        Ok(())
     }
 
     pub fn check_win(&self) -> bool {
-        for i in 0..4 {
-            if self.check_row(i) || self.check_col(i) {
+        for &mask in WINNING_MASKS.iter() {
+            if self.check_line(mask) {
                 return true;
             }
         }
-        self.check_diagonals()
+        false
     }
 
-    fn check_row(&self, row: usize) -> bool {
-        self.check_line(
-            self.grid[row][0],
-            self.grid[row][1],
-            self.grid[row][2],
-            self.grid[row][3],
-        )
-    }
+    // ピースが置かれていないセルの位置を高速に取得
+    pub fn available_positions(&self) -> Vec<(usize, usize)> {
+        let mut positions = Vec::new();
+        let mut remaining = self.empty_cells;
 
-    fn check_col(&self, col: usize) -> bool {
-        self.check_line(
-            self.grid[0][col],
-            self.grid[1][col],
-            self.grid[2][col],
-            self.grid[3][col],
-        )
-    }
-
-    fn check_diagonals(&self) -> bool {
-        self.check_line(
-            self.grid[0][0],
-            self.grid[1][1],
-            self.grid[2][2],
-            self.grid[3][3],
-        ) || self.check_line(
-            self.grid[0][3],
-            self.grid[1][2],
-            self.grid[2][1],
-            self.grid[3][0],
-        )
-    }
-
-    fn check_line(
-        &self,
-        a: Option<Piece>,
-        b: Option<Piece>,
-        c: Option<Piece>,
-        d: Option<Piece>,
-    ) -> bool {
-        match (a, b, c, d) {
-            (Some(p1), Some(p2), Some(p3), Some(p4)) => {
-                let all_same_color =
-                    p1.color == p2.color && p2.color == p3.color && p3.color == p4.color;
-                let all_same_shape =
-                    p1.shape == p2.shape && p2.shape == p3.shape && p3.shape == p4.shape;
-                let all_same_height =
-                    p1.height == p2.height && p2.height == p3.height && p3.height == p4.height;
-                let all_same_surface = p1.surface == p2.surface
-                    && p2.surface == p3.surface
-                    && p3.surface == p4.surface;
-
-                all_same_color || all_same_shape || all_same_height || all_same_surface
-            }
-            _ => false,
+        while remaining != 0 {
+            let pos = remaining.trailing_zeros() as usize; // 最下位の1ビットの位置を取得
+            positions.push((pos / 4, pos % 4)); // 行と列に変換
+            remaining &= remaining - 1; // 最下位の1ビットをクリア
         }
+
+        positions
+    }
+
+    // 勝利できるセルを探す
+    pub fn find_winning_cell(&self, piece: Piece) -> Option<(usize, usize)> {
+        // 空いているセルを取得
+        let available_positions = self.available_positions();
+
+        // 各属性のビットボードにおけるピースの属性
+        let attributes = [
+            (&self.color_board, piece.color()),
+            (&self.shape_board, piece.shape()),
+            (&self.height_board, piece.height()),
+            (&self.surface_board, piece.surface()),
+        ];
+
+        for (row, col) in available_positions {
+            let position = 1 << (row * 4 + col);
+
+            for &(board, value) in &attributes {
+                let temp_board = if value == 0 { *board | position } else { *board };
+                
+                // 勝利判定をビット演算で確認
+                if WINNING_MASKS.iter().any(|&mask| temp_board & mask == mask) {
+                    return Some((row, col)); // 勝利できる位置を返す
+                }
+            }
+        }
+
+        None // 勝利できる位置が存在しない場合
+    }
+
+    pub fn is_full(&self) -> bool {
+        self.empty_cells == 0
+    }
+
+    pub fn grid(&self) -> [[Option<Piece>; 4]; 4] {
+        let mut grid = [[None; 4]; 4];
+
+        for row in 0..4 {
+            for col in 0..4 {
+                let position = 1 << (row * 4 + col);
+
+                if self.empty_cells & position == 0 {
+                    // ピースが配置されている場合
+                    let color = if self.color_board & position != 0 {
+                        1
+                    } else {
+                        0
+                    };
+                    let shape = if self.shape_board & position != 0 {
+                        1
+                    } else {
+                        0
+                    };
+                    let height = if self.height_board & position != 0 {
+                        1
+                    } else {
+                        0
+                    };
+                    let surface = if self.surface_board & position != 0 {
+                        1
+                    } else {
+                        0
+                    };
+                    grid[row][col] = Some(Piece::new(color, shape, height, surface));
+                }
+            }
+        }
+
+        grid
+    }
+
+    fn check_line(&self, mask: u16) -> bool {
+        (self.color_board & mask == mask)
+            || (self.shape_board & mask == mask)
+            || (self.height_board & mask == mask)
+            || (self.surface_board & mask == mask)
+    }
+}
+
+impl Serialize for Board {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("Board", 1)?;
+        state.serialize_field("grid", &self.grid())?;
+        state.end()
     }
 }

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -85,8 +85,7 @@ impl Game {
     }
 
     pub fn is_game_over(&self) -> bool {
-        let board_is_full = self.available_pieces.is_empty() && self.selected_piece.is_none();
-        self.board.check_win() || board_is_full
+        self.board.check_win() || self.board.is_full()
     }
 
     // 勝者がいる場合はSome(Player)を返し、引き分けの場合はNoneを返す

--- a/src/game/piece.rs
+++ b/src/game/piece.rs
@@ -1,21 +1,49 @@
+use serde::ser::SerializeStruct;
+use serde::Serializer;
 use serde::{Deserialize, Serialize};
 
-// Define traits as simple integers
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct Piece {
-    pub color: u8,  // 0 for Black, 1 for White
-    pub shape: u8,  // 0 for Round, 1 for Square
-    pub height: u8, // 0 for Tall, 1 for Short
-    pub surface: u8, // 0 for Hollow, 1 for Solid
-}
+// 16ビットで表現される Piece
+#[derive(Copy, Clone, Debug, PartialEq, Deserialize)]
+pub struct Piece(u16);
 
 impl Piece {
     pub fn new(color: u8, shape: u8, height: u8, surface: u8) -> Self {
-        Piece {
-            color,
-            shape,
-            height,
-            surface,
-        }
+        let mut piece = 0u16;
+        piece |= (color as u16) << 0; // 色は下位ビットから1ビット目
+        piece |= (shape as u16) << 1; // 形は下位ビットから2ビット目
+        piece |= (height as u16) << 2; // 高さは下位ビットから3ビット目
+        piece |= (surface as u16) << 3; // 表面は下位ビットから4ビット目
+        Piece(piece)
+    }
+
+    // 各属性のゲッター
+    pub fn color(&self) -> u8 {
+        (self.0 & 0b0001) as u8
+    }
+
+    pub fn shape(&self) -> u8 {
+        ((self.0 >> 1) & 0b0001) as u8
+    }
+
+    pub fn height(&self) -> u8 {
+        ((self.0 >> 2) & 0b0001) as u8
+    }
+
+    pub fn surface(&self) -> u8 {
+        ((self.0 >> 3) & 0b0001) as u8
+    }
+}
+
+impl Serialize for Piece {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("Piece", 4)?;
+        state.serialize_field("color", &self.color())?;
+        state.serialize_field("shape", &self.shape())?;
+        state.serialize_field("height", &self.height())?;
+        state.serialize_field("surface", &self.surface())?;
+        state.end()
     }
 }

--- a/src/policies/random_policy.rs
+++ b/src/policies/random_policy.rs
@@ -15,10 +15,7 @@ impl Policy for RandomPolicy {
         let mut rng = thread_rng();
 
         // 利用可能な位置を取得する
-        let available_positions: Vec<(usize, usize)> = (0..4)
-            .flat_map(|row| (0..4).map(move |col| (row, col)))
-            .filter(|&(row, col)| game.board.grid[row][col].is_none())
-            .collect();
+        let available_positions: Vec<(usize, usize)> = game.board.available_positions();
 
         // 利用可能な位置がない場合のエラーチェック
         if available_positions.is_empty() {

--- a/tests/game_test.rs
+++ b/tests/game_test.rs
@@ -6,7 +6,7 @@ use tqdm::tqdm;
 
 #[test]
 fn test_random_policy() {
-    let num_trials = 10000;
+    let num_trials = 1000000;
     // random policy vs random policyでnum_trials回ゲームを実行する
     let mut win_count = 0;
     for _ in tqdm(0..num_trials) {


### PR DESCRIPTION
盤面をビットボードで表現することによって、勝敗判定や駒の配置を高速化
参考: https://speakerdeck.com/antenna_three/bitutobodojie-shuo